### PR TITLE
update base image docs, add flag to disable DRI3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,7 @@ ENV DISPLAY=:1 \
     SELKIES_INTERPOSER=/usr/lib/selkies_joystick_interposer.so \
     NVIDIA_DRIVER_CAPABILITIES=all \
     DISABLE_ZINK=false \
+    DISABLE_DRI3=false \
     TITLE=Selkies
 
 RUN \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -58,6 +58,7 @@ ENV DISPLAY=:1 \
     SELKIES_INTERPOSER=/usr/lib/selkies_joystick_interposer.so \
     NVIDIA_DRIVER_CAPABILITIES=all \
     DISABLE_ZINK=false \
+    DISABLE_DRI3=false \
     TITLE=Selkies
 
 RUN \

--- a/README.md
+++ b/README.md
@@ -28,21 +28,24 @@ All application settings are passed via environment variables:
 
 | Variable | Description |
 | :----: | --- |
-| CUSTOM_PORT | Internal port the container listens on for http if it needs to be swapped from the default 3000. |
-| CUSTOM_HTTPS_PORT | Internal port the container listens on for https if it needs to be swapped from the default 3001. |
-| CUSTOM_WS_PORT | Internal port the container listens on for websockets if it needs to be swapped from the default 8082. |
+| CUSTOM_PORT | Internal port the container listens on for http if it needs to be swapped from the default 3000 |
+| CUSTOM_HTTPS_PORT | Internal port the container listens on for https if it needs to be swapped from the default 3001 |
+| CUSTOM_WS_PORT | Internal port the container listens on for websockets if it needs to be swapped from the default 8082 |
 | CUSTOM_USER | HTTP Basic auth username, abc is default. |
+| DRI_NODE | Enable VAAPI stream encoding and use the specified device IE `/dev/dri/renderD128` |
+| DRINODE | Specify which GPU to use for DRI3 acceleration IE `/dev/dri/renderD129` |
 | PASSWORD | HTTP Basic auth password, abc is default. If unset there will be no auth |
 | SUBFOLDER | Subfolder for the application if running a subfolder reverse proxy, need both slashes IE `/subfolder/` |
-| TITLE | The page title displayed on the web browser, default "Selkies". |
-| DASHBOARD | Allows the user to set their dashboard. Options: `selkies-dashboard`, `selkies-dashboard-zinc`, `selkies-dashboard-wish`. |
-| FILE_MANAGER_PATH | Modifies the default upload/download file path, path must have proper permissions for abc user. |
-| START_DOCKER | If set to false a container with privilege will not automatically start the DinD Docker setup. |
+| TITLE | The page title displayed on the web browser, default "Selkies" |
+| DASHBOARD | Allows the user to set their dashboard. Options: `selkies-dashboard`, `selkies-dashboard-zinc`, `selkies-dashboard-wish` |
+| FILE_MANAGER_PATH | Modifies the default upload/download file path, path must have proper permissions for abc user |
+| START_DOCKER | If set to false a container with privilege will not automatically start the DinD Docker setup |
 | DISABLE_IPV6 | If set to true or any value this will disable IPv6 |
 | LC_ALL | Set the Language for the container to run as IE `fr_FR.UTF-8` `ar_AE.UTF-8` |
 | NO_DECOR | If set the application will run without window borders for use as a PWA. (Decor can be enabled and disabled with Ctrl+Shift+d) |
 | NO_FULL | Do not autmatically fullscreen applications when using openbox. |
 | DISABLE_ZINK | Do not set the Zink environment variables if a video card is detected (userspace applications will use CPU rendering) |
+| DISABLE_DRI3 | Do not use DRI3 acceleration if a video card is detected (userspace applications will use CPU rendering) |
 | MAX_RES | Pass a larger maximum resolution for the container default is 16k `15360x8640` |
 | WATERMARK_PNG | Full path inside the container to a watermark png IE `/usr/share/selkies/www/icon.png` |
 | WATERMARK_LOCATION | Where to paint the image over the stream integer options below |

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -32,21 +32,24 @@ full_custom_readme: |
 
   | Variable | Description |
   | :----: | --- |
-  | CUSTOM_PORT | Internal port the container listens on for http if it needs to be swapped from the default 3000. |
-  | CUSTOM_HTTPS_PORT | Internal port the container listens on for https if it needs to be swapped from the default 3001. |
-  | CUSTOM_WS_PORT | Internal port the container listens on for websockets if it needs to be swapped from the default 8082. |
+  | CUSTOM_PORT | Internal port the container listens on for http if it needs to be swapped from the default 3000 |
+  | CUSTOM_HTTPS_PORT | Internal port the container listens on for https if it needs to be swapped from the default 3001 |
+  | CUSTOM_WS_PORT | Internal port the container listens on for websockets if it needs to be swapped from the default 8082 |
   | CUSTOM_USER | HTTP Basic auth username, abc is default. |
+  | DRI_NODE | Enable VAAPI stream encoding and use the specified device IE `/dev/dri/renderD128` |
+  | DRINODE | Specify which GPU to use for DRI3 acceleration IE `/dev/dri/renderD129` |
   | PASSWORD | HTTP Basic auth password, abc is default. If unset there will be no auth |
   | SUBFOLDER | Subfolder for the application if running a subfolder reverse proxy, need both slashes IE `/subfolder/` |
-  | TITLE | The page title displayed on the web browser, default "Selkies". |
-  | DASHBOARD | Allows the user to set their dashboard. Options: `selkies-dashboard`, `selkies-dashboard-zinc`, `selkies-dashboard-wish`. |
-  | FILE_MANAGER_PATH | Modifies the default upload/download file path, path must have proper permissions for abc user. |
-  | START_DOCKER | If set to false a container with privilege will not automatically start the DinD Docker setup. |
+  | TITLE | The page title displayed on the web browser, default "Selkies" |
+  | DASHBOARD | Allows the user to set their dashboard. Options: `selkies-dashboard`, `selkies-dashboard-zinc`, `selkies-dashboard-wish` |
+  | FILE_MANAGER_PATH | Modifies the default upload/download file path, path must have proper permissions for abc user |
+  | START_DOCKER | If set to false a container with privilege will not automatically start the DinD Docker setup |
   | DISABLE_IPV6 | If set to true or any value this will disable IPv6 |
   | LC_ALL | Set the Language for the container to run as IE `fr_FR.UTF-8` `ar_AE.UTF-8` |
   | NO_DECOR | If set the application will run without window borders for use as a PWA. (Decor can be enabled and disabled with Ctrl+Shift+d) |
   | NO_FULL | Do not autmatically fullscreen applications when using openbox. |
   | DISABLE_ZINK | Do not set the Zink environment variables if a video card is detected (userspace applications will use CPU rendering) |
+  | DISABLE_DRI3 | Do not use DRI3 acceleration if a video card is detected (userspace applications will use CPU rendering) |
   | MAX_RES | Pass a larger maximum resolution for the container default is 16k `15360x8640` |
   | WATERMARK_PNG | Full path inside the container to a watermark png IE `/usr/share/selkies/www/icon.png` |
   | WATERMARK_LOCATION | Where to paint the image over the stream integer options below |

--- a/root/etc/s6-overlay/s6-rc.d/svc-selkies/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-selkies/run
@@ -56,7 +56,6 @@ if [ ! -z ${DEV_MODE+x} ]; then
       --mode="websockets"
 fi
 
-
 # Start Selkies
 exec s6-setuidgid abc \
   selkies \

--- a/root/etc/s6-overlay/s6-rc.d/svc-xorg/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-xorg/run
@@ -8,6 +8,9 @@ fi
 if [ ! -z ${DRINODE+x} ]; then
   VFBCOMMAND="-vfbdevice ${DRINODE}"
 fi
+if [ "${DISABLE_DRI3}" != "false" ]; then
+  VFBCOMMAND=""
+fi
 DEFAULT_RES="15360x8640"
 if [ ! -z ${MAX_RES+x} ]; then
   DEFAULT_RES="${MAX_RES}"


### PR DESCRIPTION
Time to advertise the DRI_NODE env var better as vaapi should now work for most people, will flag default when the DRI3 stuff is more flushed out. 

Also add a flag to disable DRI3, on low end intel systems the best combo is 
```
-e DRI_NODE=/dev/dri/renderD128 -e DISABLE_DRI3=true
```
Unless 3d accel is needed. 

Will update the core docs here for downstream images [here](https://github.com/linuxserver/docker-jenkins-builder/blob/master/ansible/roles/documentation/templates/README_SNIPPETS/SELKIES.j2) when this burns in for a bit. 