### PR TITLE
Fix NO_DECOR handler

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-selkies-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-selkies-config/run
@@ -146,7 +146,7 @@ if [[ ${DISABLE_MOUSE_BUTTONS,,} == "true" ]]; then
 fi
 if [[ ! -z ${NO_DECOR+x} ]]; then
   echo "[ls.io-init] Removing window decorations"
-  sed -i '/<application class="\*">/a \    <decor>no</decor>' "$SYS_RC_XML"
+  sed -i 's/<application class="\*">/&<decor>no<\/decor>/' "$SYS_RC_XML"
 fi
 if [[ ! -z ${NO_FULL+x} ]]; then
   echo "[ls.io-init] Disabling maximization"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-baseimage-selkies/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->

The following code
https://github.com/linuxserver/docker-baseimage-selkies/blob/3eaac97d54af616a79ce01bcd025ef0a700bb38a/root/etc/s6-overlay/s6-rc.d/init-selkies-config/run#L147-L150
results in wrong OpenBox configuration:
```
  <application class="*"><maximized>yes</maximized></application>
    <decor>no</decor>
```

The PR changes move a `<decor>` tag into an `<application>` tag:
```
  <application class="*"><decor>no</decor><maximized>yes</maximized></application>
```


## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Current implementation doesn't allow to disable windows decoration. The PR fixes the bug. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. A new Docker image was created on the basis of https://github.com/linuxserver/docker-obsidian
2. A fixed version of `/etc/s6-overlay/s6-rc.d/init-selkies-config/run` was included to the image
3. `/config/.config/openbox/rc.xml` was verified after container startup


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
