### PR TITLE
nginx: add /websockets plural alias with path rewrite to selkies /ws

### DIFF
--- a/root/defaults/default.conf
+++ b/root/defaults/default.conf
@@ -38,6 +38,24 @@ server {
     client_max_body_size    10M;
     proxy_pass              http://127.0.0.1:CWS;
   }
+  # Plural alias for /websockets used by selkies-dashboard frontend
+  # (selkies-ws-core.js builds the URL as `${pathname}websockets`).
+  # Selkies signaling-server only recognises /ws, hence the path rewrite.
+  location SUBFOLDERwebsockets {
+    proxy_set_header        Upgrade $http_upgrade;
+    proxy_set_header        Connection "upgrade";
+    proxy_set_header        Host $host;
+    proxy_set_header        X-Real-IP $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header        X-Forwarded-Proto $scheme;
+    proxy_http_version      1.1;
+    proxy_read_timeout      3600s;
+    proxy_send_timeout      3600s;
+    proxy_connect_timeout   3600s;
+    proxy_buffering         off;
+    client_max_body_size    10M;
+    proxy_pass              http://127.0.0.1:CWS/ws;
+  }
   location SUBFOLDERfiles {
     fancyindex on;
     fancyindex_footer SUBFOLDERnginx/footer.html;
@@ -95,6 +113,24 @@ server {
     proxy_buffering         off;
     client_max_body_size    10M;
     proxy_pass              http://127.0.0.1:CWS;
+  }
+  # Plural alias for /websockets used by selkies-dashboard frontend
+  # (selkies-ws-core.js builds the URL as `${pathname}websockets`).
+  # Selkies signaling-server only recognises /ws, hence the path rewrite.
+  location SUBFOLDERwebsockets {
+    proxy_set_header        Upgrade $http_upgrade;
+    proxy_set_header        Connection "upgrade";
+    proxy_set_header        Host $host;
+    proxy_set_header        X-Real-IP $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header        X-Forwarded-Proto $scheme;
+    proxy_http_version      1.1;
+    proxy_read_timeout      3600s;
+    proxy_send_timeout      3600s;
+    proxy_connect_timeout   3600s;
+    proxy_buffering         off;
+    client_max_body_size    10M;
+    proxy_pass              http://127.0.0.1:CWS/ws;
   }
   location SUBFOLDERfiles {
     fancyindex on;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

- [x] I have read the [contributing](https://github.com/linuxserver/docker-baseimage-selkies/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:

Add an `nginx` location block for the plural `/websockets` URL that the selkies-dashboard frontend builds in WebSocket mode, with a path rewrite to selkies' `/ws` endpoint.

```nginx
location SUBFOLDERwebsockets {
    proxy_set_header        Upgrade $http_upgrade;
    proxy_set_header        Connection "upgrade";
    ...
    proxy_pass              http://127.0.0.1:CWS/ws;
}
```

Done in both the `:3000` and the `:3001` server blocks of `root/defaults/default.conf`.

## Benefits of this PR and context:

Out of the box, opening a freshly started `lscr.io/linuxserver/baseimage-selkies`-derived container in a browser logs:

```
Firefox can't establish a connection to the server at wss://<host>/websockets.
[websockets] Error: WebSocket connection refused
```

Three independent path conventions are in play:

- The frontend (`addons/selkies-web-core/selkies-ws-core.js` upstream) builds the URL as `${ws_protocol}${window.location.host}${pathname}websockets` (plural).
- The bundled nginx config in this repo only declares `location SUBFOLDERwebsocket {}` (singular).
- The selkies signaling server in `src/selkies/signaling_server.py` upgrades to WebSocket only for `path == "/ws"` or paths ending in `/signaling`.

So even a singular `/websocket` request would 404 inside selkies.

The proposed change makes the default install work end-to-end without patching either the frontend or selkies, by exposing the URL the frontend already uses and rewriting it to the path the server expects. The existing singular `/websocket` location is left untouched for backwards compatibility with anything that may already point at it.

## How Has This Been Tested?

Built locally from this branch on top of the upstream `master` (`debian-trixie` variant), then composed a webtop-style layer on top (`debian-xfce`) and ran it on a Linux x86_64 host with:

```
docker run -d \
  -p 3010:3000 \
  -e PUID=1000 -e PGID=1000 -e TZ=Europe/Berlin \
  -e SELKIES_TURN_HOST=... \
  -e SELKIES_TURN_PORT=3478 \
  -e SELKIES_TURN_PROTOCOL=udp \
  -e SELKIES_TURN_SHARED_SECRET=... \
  --shm-size=1g --cap-add SYS_ADMIN \
  webtop:patched
```

Validated in Firefox 149 and Chromium 142 on Ubuntu:

- Before patch: `NS_ERROR_WEBSOCKET_CONNECTION_REFUSED` on `wss://<host>/websockets`, dashboard fails to load.
- After patch: WebSocket upgrade returns `HTTP/1.1 101 Switching Protocols`, dashboard connects, MATE/XFCE desktop renders, input round-trip works.

Also verified directly:

```
$ curl -i -H 'Upgrade: websocket' -H 'Connection: Upgrade' \
       -H 'Sec-WebSocket-Key: <16 random bytes b64>' \
       -H 'Sec-WebSocket-Version: 13' \
       https://<host>/websockets
HTTP/1.1 101 Switching Protocols
```

## Source / References:

- Frontend URL construction: `addons/selkies-web-core/selkies-ws-core.js` upstream of `selkies-project/selkies`, the line `websocketEndpointURL.pathname += 'websockets'`.
- Server-side path matching: `src/selkies/signaling_server.py` upstream, the `process_request` method that returns `None` (i.e. accepts WS upgrade) only for `/ws`, `/ws/`, `/signaling` and `/signaling/`.
