### PR TITLE
svc-selkies: honor SELKIES_MODE env var in run script

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/svc-selkies/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-selkies/run
@@ -55,7 +55,7 @@ if [ ! -z ${DEV_MODE+x} ]; then
     nodemon -V --ext py --exec \
       "python3" -m selkies \
       --addr="localhost" \
-      --mode="websockets" \
+      --mode="${SELKIES_MODE:-websockets}" \
       --debug="true"
 fi
 
@@ -63,4 +63,4 @@ fi
 exec s6-setuidgid abc \
   selkies \
     --addr="localhost" \
-    --mode="websockets"
+    --mode="${SELKIES_MODE:-websockets}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

- [x] I have read the [contributing](https://github.com/linuxserver/docker-baseimage-selkies/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:

Replace the hardcoded `--mode="websockets"` in the svc-selkies s6 run script with `--mode="${SELKIES_MODE:-websockets}"`, in both the production exec and the DEV_MODE branch.

## Benefits of this PR and context:

Selkies declares a `mode` setting with `env_var: SELKIES_MODE` (see `src/selkies/settings.py`):

```python
{'name': 'mode', 'type': 'str', 'default': 'websockets',
 'env_var': 'SELKIES_MODE',
 'help': "Specify the mode: 'webrtc' or 'websockets'; defaults to websockets"}
```

But because the run script passes `--mode="websockets"` on the command line, the hardcoded value wins over the env var. Setting `-e SELKIES_MODE=webrtc` on the container has no effect; users have to either patch the run script at runtime or live-edit the compiled `/run/service/svc-selkies/run`.

After this change, the env var works as documented: the default behaviour stays `websockets` while `-e SELKIES_MODE=webrtc` actually selects WebRTC mode at startup. Combined with the dual-mode supervisor (separate PRs), this lets users choose the initial mode declaratively.

## How Has This Been Tested?

```
docker run -d -e SELKIES_MODE=webrtc ... webtop:patched
docker exec <id> ps -o pid,cmd | grep selkies
> /lsiopy/bin/python3 /lsiopy/bin/selkies --addr=localhost --mode=webrtc
```

Without env var:

```
docker run -d ... webtop:patched
docker exec <id> ps -o pid,cmd | grep selkies
> /lsiopy/bin/python3 /lsiopy/bin/selkies --addr=localhost --mode=websockets
```

Default behaviour preserved.

## Source / References:

- Setting definition: `selkies-project/selkies` `src/selkies/settings.py`, field `mode` with `env_var: SELKIES_MODE`.
- Affected file in this repo: `root/etc/s6-overlay/s6-rc.d/svc-selkies/run`.
