### PR TITLE
nginx: route /turn (REST) and /webrtc/signaling/ (WS) to selkies

### DIFF
--- a/root/defaults/default.conf
+++ b/root/defaults/default.conf
@@ -48,6 +48,26 @@ server {
         add_header X-Content-Type-Options "nosniff";
     }
   }
+  # Selkies signaling-server (upstream selkies, src/selkies/signaling_server.py)
+  # exposes a few HTTP endpoints next to the WebSocket upgrade handler:
+  # /turn returns the TURN/STUN config as JSON, and any path ending in
+  # /signaling is upgraded to a WebSocket for the WebRTC peer-handshake.
+  # The selkies-dashboard frontend connects to /webrtc/signaling/ when the
+  # streamMode is "webrtc", and fetches /turn for TURN credentials.
+  location SUBFOLDERturn {
+    proxy_set_header        Host $host;
+    proxy_http_version      1.1;
+    proxy_buffering         off;
+    proxy_pass              http://127.0.0.1:CWS;
+  }
+  location ~ ^/webrtc/signaling/?$ {
+    proxy_set_header        Upgrade $http_upgrade;
+    proxy_set_header        Connection "upgrade";
+    proxy_set_header        Host $host;
+    proxy_http_version      1.1;
+    proxy_buffering         off;
+    proxy_pass              http://127.0.0.1:CWS;
+  }
   error_page 500 502 503 504 /50x.html;
   location = SUBFOLDER50x.html {
     root /usr/share/selkies/web/;
@@ -106,6 +126,26 @@ server {
         add_header X-Content-Type-Options "nosniff";
     }
   } 
+  # Selkies signaling-server (upstream selkies, src/selkies/signaling_server.py)
+  # exposes a few HTTP endpoints next to the WebSocket upgrade handler:
+  # /turn returns the TURN/STUN config as JSON, and any path ending in
+  # /signaling is upgraded to a WebSocket for the WebRTC peer-handshake.
+  # The selkies-dashboard frontend connects to /webrtc/signaling/ when the
+  # streamMode is "webrtc", and fetches /turn for TURN credentials.
+  location SUBFOLDERturn {
+    proxy_set_header        Host $host;
+    proxy_http_version      1.1;
+    proxy_buffering         off;
+    proxy_pass              http://127.0.0.1:CWS;
+  }
+  location ~ ^/webrtc/signaling/?$ {
+    proxy_set_header        Upgrade $http_upgrade;
+    proxy_set_header        Connection "upgrade";
+    proxy_set_header        Host $host;
+    proxy_http_version      1.1;
+    proxy_buffering         off;
+    proxy_pass              http://127.0.0.1:CWS;
+  }
   error_page 500 502 503 504 /50x.html;
   location = SUBFOLDER50x.html {
     root /usr/share/selkies/web/;

--- a/root/defaults/default.conf
+++ b/root/defaults/default.conf
@@ -56,16 +56,26 @@ server {
   # streamMode is "webrtc", and fetches /turn for TURN credentials.
   location SUBFOLDERturn {
     proxy_set_header        Host $host;
+    proxy_set_header        X-Real-IP $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header        X-Forwarded-Proto $scheme;
     proxy_http_version      1.1;
     proxy_buffering         off;
     proxy_pass              http://127.0.0.1:CWS;
   }
-  location ~ ^/webrtc/signaling/?$ {
+  location ~ ^SUBFOLDERwebrtc/signaling/?$ {
     proxy_set_header        Upgrade $http_upgrade;
     proxy_set_header        Connection "upgrade";
     proxy_set_header        Host $host;
+    proxy_set_header        X-Real-IP $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header        X-Forwarded-Proto $scheme;
     proxy_http_version      1.1;
+    proxy_read_timeout      3600s;
+    proxy_send_timeout      3600s;
+    proxy_connect_timeout   3600s;
     proxy_buffering         off;
+    client_max_body_size    10M;
     proxy_pass              http://127.0.0.1:CWS;
   }
   error_page 500 502 503 504 /50x.html;
@@ -134,16 +144,26 @@ server {
   # streamMode is "webrtc", and fetches /turn for TURN credentials.
   location SUBFOLDERturn {
     proxy_set_header        Host $host;
+    proxy_set_header        X-Real-IP $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header        X-Forwarded-Proto $scheme;
     proxy_http_version      1.1;
     proxy_buffering         off;
     proxy_pass              http://127.0.0.1:CWS;
   }
-  location ~ ^/webrtc/signaling/?$ {
+  location ~ ^SUBFOLDERwebrtc/signaling/?$ {
     proxy_set_header        Upgrade $http_upgrade;
     proxy_set_header        Connection "upgrade";
     proxy_set_header        Host $host;
+    proxy_set_header        X-Real-IP $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header        X-Forwarded-Proto $scheme;
     proxy_http_version      1.1;
+    proxy_read_timeout      3600s;
+    proxy_send_timeout      3600s;
+    proxy_connect_timeout   3600s;
     proxy_buffering         off;
+    client_max_body_size    10M;
     proxy_pass              http://127.0.0.1:CWS;
   }
   error_page 500 502 503 504 /50x.html;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

- [x] I have read the [contributing](https://github.com/linuxserver/docker-baseimage-selkies/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:

Add two missing nginx locations:

- `SUBFOLDERturn` (HTTP) — proxies `GET /turn` to the selkies signaling server, which returns the ICE configuration JSON.
- `^/webrtc/signaling/?$` (regex, WebSocket-upgrade) — proxies the WebRTC-mode signaling URL to the same selkies process.

Done in both the `:3000` and the `:3001` server blocks of `root/defaults/default.conf`.

## Benefits of this PR and context:

The selkies dashboard issues two requests during initialisation that currently fall through to nginx's default 404 handler:

1. `fetch('./turn')` — the dashboard expects the JSON response defined in `selkies/signaling_server.py` (`if path == "/turn": ...`). With no nginx route, the browser receives an HTML 404 page and the dashboard logs `Uncaught (in promise) SyntaxError: Unexpected token '<', "<html>..."`.
2. `new WebSocket('wss://.../webrtc/signaling/')` — built by `selkies-wr-core.js` (`new URL(protocol + window.location.host + pathname + appName + "/signaling/")`, with `appName === "webrtc"`). The selkies signaling server upgrades any path ending in `/signaling/` but the bundled nginx config has no matching location, so the browser sees `NS_ERROR_WEBSOCKET_CONNECTION_REFUSED`.

With these two locations in place, both `SELKIES_MODE=webrtc` and dual mode work without any container-side patching.

## How Has This Been Tested?

Built locally on top of `master` (debian-trixie), composed an `debian-xfce`-style downstream image, ran with:

```
docker run -d \
  -p 3010:3000 \
  -e PUID=1000 -e PGID=1000 -e TZ=Europe/Berlin \
  -e SELKIES_MODE=webrtc \
  -e SELKIES_ENABLE_DUAL_MODE=true \
  -e SELKIES_TURN_HOST=... -e SELKIES_TURN_PORT=3478 \
  -e SELKIES_TURN_PROTOCOL=udp -e SELKIES_TURN_SHARED_SECRET=... \
  webtop:patched
```

Validated with:

```
$ curl -i https://<host>/turn
HTTP/1.1 200 OK
Content-Type: text/plain; charset=utf-8
{ "lifetimeDuration": "86400s", "iceServers": [ ... ] }
```

WebSocket upgrade for the WebRTC signaling URL returns 101:

```
$ curl -i -H 'Upgrade: websocket' -H 'Connection: Upgrade' \
       -H 'Sec-WebSocket-Key: <16 random bytes b64>' \
       -H 'Sec-WebSocket-Version: 13' \
       https://<host>/webrtc/signaling/
HTTP/1.1 101 Switching Protocols
```

Browser end-to-end: dashboard initialises, peer connection establishes, H.264 video and Opus audio render in Firefox 149 + Chromium 142.

## Source / References:

- TURN endpoint handler: `src/selkies/signaling_server.py`, the branch `if path == "/turn/" or path == "/turn":` in `process_request`.
- WebRTC signaling path construction: `addons/selkies-web-core/selkies-wr-core.js` upstream, the `new URL(protocol + window.location.host + pathname + appName + "/signaling/")` call with `appName === "webrtc"` from selkies-dashboard's WebRTC mode.
