### PR TITLE
bump selkies, ingest file_transfers validator fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN \
     https://github.com/selkies-project/selkies.git \
     /src && \
   cd /src && \
-  git checkout -f a49d310a5f613c4750195bc1fdbe1296afaebc34
+  git checkout -f 38f0bed816c09b593cbb74b16b8bac5f7210345c
 
 RUN \
   echo "**** build shared core library ****" && \
@@ -282,7 +282,7 @@ RUN \
     | awk '/tag_name/{print $4;exit}' FS='[""]') && \
   curl -o \
     /tmp/selkies.tar.gz -L \
-    "https://github.com/selkies-project/selkies/archive/a49d310a5f613c4750195bc1fdbe1296afaebc34.tar.gz" && \
+    "https://github.com/selkies-project/selkies/archive/38f0bed816c09b593cbb74b16b8bac5f7210345c.tar.gz" && \
   cd /tmp && \
   tar xf selkies.tar.gz && \
   cd selkies-* && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -16,7 +16,7 @@ RUN \
     https://github.com/selkies-project/selkies.git \
     /src && \
   cd /src && \
-  git checkout -f a49d310a5f613c4750195bc1fdbe1296afaebc34
+  git checkout -f 38f0bed816c09b593cbb74b16b8bac5f7210345c
 
 RUN \
   echo "**** build shared core library ****" && \
@@ -280,7 +280,7 @@ RUN \
     | awk '/tag_name/{print $4;exit}' FS='[""]') && \
   curl -o \
     /tmp/selkies.tar.gz -L \
-    "https://github.com/selkies-project/selkies/archive/a49d310a5f613c4750195bc1fdbe1296afaebc34.tar.gz" && \
+    "https://github.com/selkies-project/selkies/archive/38f0bed816c09b593cbb74b16b8bac5f7210345c.tar.gz" && \
   cd /tmp && \
   tar xf selkies.tar.gz && \
   cd selkies-* && \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-baseimage-selkies/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:

Bumps the pinned Selkies SHA from `a49d310a` to `38f0bed8` in both `Dockerfile` and `Dockerfile.aarch64` (4 occurrences total of the same SHA, +4/−4 net).

`38f0bed8` is current `selkies-project/selkies` `main` HEAD and is the merge commit of [selkies-project/selkies#243](https://github.com/selkies-project/selkies/pull/243). No other commits between the previous pin and this one on `main`, so the diff is the validator fix only.

## Benefits of this PR and context:

#243 fixes a list-type validator bug in `src/selkies/settings.py` where `SELKIES_FILE_TRANSFERS=none` (and `""`) — both documented in the help text as the way to disable transfers — were rejected by the `meta.allowed` filter and silently fell back to the system default `upload,download`. The user's intent to disable file transfers from the environment was lost.

After the fix the validator resolves `'none'`/`''` to `[]` correctly. `enum` semantics and the existing typo warn-and-fallback path (e.g. `SELKIES_FILE_TRANSFERS=uploadx`) are unchanged.

The most recent baseimage bump (`2df5f01`, 2026-05-03) pinned a SHA dated several hours after #243 merged but on a divergent line of history that does not include it, so users on the latest baseimage still hit the original behaviour. This PR aligns the pin with `main` HEAD.

## How Has This Been Tested?

Validated upstream (selkies-project/selkies) before the merge with a Python harness importing `selkies.settings` after setting `SELKIES_FILE_TRANSFERS` to each of: `none`, `""`, `upload`, `upload,download`, `uploadx`, and unset. Results matrix in the upstream PR description: pre-fix `none`/`""` → `['upload','download']` (silent fallback with `WARNING`); post-fix → `[]` (no warning). Typo path (`uploadx`) and enum semantics unchanged.

I did not rebuild the LinuxServer baseimage locally for this PR — the change is a pinned-SHA bump only, with no Dockerfile structure or build-step changes, so the existing CI build should validate the integration.

## Source / References:

- Upstream Selkies issue: https://github.com/selkies-project/selkies/issues/239
- Upstream Selkies PR (merged): https://github.com/selkies-project/selkies/pull/243
- Original upstream PR (closed, superseded by #243 with attribution): https://github.com/selkies-project/selkies/pull/240