### PR TITLE
fix manifest start_url when using SUBFOLDER

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-nginx/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-nginx/run
@@ -80,5 +80,5 @@ echo "{
       \"sizes\": \"180x180\"
     }
   ],
-  \"start_url\": \"/\"
+  \"start_url\": \"${SFOLDER}\"
 }" > /usr/share/selkies/web/manifest.json


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-baseimage-selkies/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:

Fix the `start_url` parameter for the PWA when SUBFOLDER is used.

## Benefits of this PR and context:

When using the `SUBFOLDER` parameter of the docker image, the resulting PWA was using the wrong url when starting.

<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
docker run --rm -it \
  --shm-size=1gb \
  -p 3001:3001 \
  --device /dev/dri \
  -e SUBFOLDER=/test/ \
  -e PIXELFLUX_WAYLAND=true \
  -e AUTO_GPU=true \
  test_pwa_subfolder
```

Then install the PWA (tested on chrome 131.0.6778.69, Fedora 44) , and launch it. I checked the resulting `manifest.json` to look at the `start_url: /test/` parameter.

I also tested without `-e SUBFOLDER=/test/`.

## Source / References:
https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Manifest/Reference/start_url


(by the way, didn't find the changelog in the repo)