### PR TITLE
fix: add NVIDIA GBM EGL platform fallback

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-video/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-video/run
@@ -83,6 +83,21 @@ EOF
 }
 EOF
     fi
+    # find nvidia gbm egl_external_platform files
+    GBM_EGLS=$(find /usr/share/egl/egl_external_platform.d /etc/egl/egl_external_platform.d -name '*nvidia*gbm*.json' 2>/dev/null)
+    # if no gbm egl_external_platform file found
+    if [ -z "${GBM_EGLS}" ]; then
+        echo "**** Setting up EGL GBM external platform file for NVIDIA ****"
+        mkdir -pm755 /etc/egl/egl_external_platform.d/
+        cat > /etc/egl/egl_external_platform.d/15_nvidia_gbm.json << EOF
+{
+    "file_format_version": "1.0.0",
+    "ICD": {
+        "library_path": "libnvidia-egl-gbm.so.1"
+    }
+}
+EOF
+    fi
     # fix gbm library linkage
     if ! ldconfig -p | grep -q "nvidia-drm_gbm.so"; then
         GBM_PATHS=(


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-baseimage-selkies/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:
Add a startup fallback for the NVIDIA GBM EGL external platform manifest.

When an NVIDIA GPU is detected, `init-video` now checks for an existing NVIDIA GBM EGL external platform JSON under:

- `/usr/share/egl/egl_external_platform.d`
- `/etc/egl/egl_external_platform.d`

If none is found, it creates:

```text
/etc/egl/egl_external_platform.d/15_nvidia_gbm.json
```

with `libnvidia-egl-gbm.so.1` as the ICD library.

## Benefits of this PR and context:
Some NVIDIA container environments provide the required driver libraries but do not install the GBM EGL external platform manifest. Without this JSON file, EGL/Wayland GBM initialization can fail even when the NVIDIA GBM library is available.

This follows the existing `init-video` pattern of creating missing NVIDIA runtime config files under `/etc` only when they are absent.

## How Has This Been Tested?

- Tested with NVIDIA GPU containers where json file was missing
- Verified EGL functionality after automatic setup (`eglinfo -B`)

## Source / References:
https://github.com/selkies-project/docker-selkies-egl-desktop/blob/8dd03fba2a33ac774d61f46375a19ed1d9c5b51a/Dockerfile#L248-L264
