### PR TITLE
Disable SELKIES_ENABLE_PLAYER4 when gamepad is disabled

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-selkies-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-selkies-config/run
@@ -298,7 +298,7 @@ else
   printf "false" > /run/s6/container_environment/SELKIES_GAMEPAD_ENABLED
   printf "false" > /run/s6/container_environment/SELKIES_ENABLE_PLAYER2
   printf "false" > /run/s6/container_environment/SELKIES_ENABLE_PLAYER3
-  printf "false" > /run/s6/container_environment/SELKIES_ENABLE_PLAYER3
+  printf "false" > /run/s6/container_environment/SELKIES_ENABLE_PLAYER4
 fi
 
 # set ws port if unset


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-baseimage-selkies/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:
When gamepad support is disabled (`NO_GAMEPAD` set, or the `mknod /dev/input/js0` probe fails), the `else` branch in `init-selkies-config/run` disables the gamepad-related Selkies env vars. It sets `SELKIES_ENABLE_PLAYER2` and `SELKIES_ENABLE_PLAYER3` to `false`, then repeats `SELKIES_ENABLE_PLAYER3` a second time instead of setting `SELKIES_ENABLE_PLAYER4`:

```bash
printf "false" > /run/s6/container_environment/SELKIES_ENABLE_PLAYER2
printf "false" > /run/s6/container_environment/SELKIES_ENABLE_PLAYER3
printf "false" > /run/s6/container_environment/SELKIES_ENABLE_PLAYER3   # <- should be PLAYER4
```

So `/run/s6/container_environment/SELKIES_ENABLE_PLAYER4` is never written and player-4 sharing keeps its default (`True`) even though no gamepad devices exist. This changes the duplicated line to target `SELKIES_ENABLE_PLAYER4`.

## Benefits of this PR and context:
`README.md` / `readme-vars.yml` document exactly three sharing-link players — `SELKIES_ENABLE_PLAYER2/3/4`, all defaulting to `True` — so all three should be turned off together in the no-gamepad branch. closes #167

## How Has This Been Tested?
Diffed the `else` block: `SELKIES_ENABLE_PLAYER2`, `PLAYER3` and `PLAYER4` now each appear exactly once. Cross-checked the variable names against `README.md` and `readme-vars.yml`. LF-only, one-line change. Reviewer runtime check: `docker run --rm -e NO_GAMEPAD=1 <image> with-contenv env | grep SELKIES_ENABLE_PLAYER` should now list `SELKIES_ENABLE_PLAYER4=false` alongside `PLAYER2`/`PLAYER3`.

## Source / References:
closes #167
