### PR TITLE
fix SELKIES_DESKTOP to accept case-insensitive values (e.g. True)

### DIFF
--- a/root/defaults/startwm_wayland.sh
+++ b/root/defaults/startwm_wayland.sh
@@ -7,7 +7,7 @@ export XCURSOR_SIZE=24
 export XKB_DEFAULT_LAYOUT=us
 export XKB_DEFAULT_RULES=evdev
 export WAYLAND_DISPLAY=wayland-1
-if [ "${SELKIES_DESKTOP}" == "true" ]; then
+if [[ "${SELKIES_DESKTOP,,}" == "true" ]]; then
   labwc > /dev/null 2>&1 &
   sleep 1
   export WAYLAND_DISPLAY=wayland-0


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-baseimage-selkies/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:
`SELKIES_DESKTOP=True` (or any non-lowercase spelling) does not enable the desktop panel — only the exact lowercase `SELKIES_DESKTOP=true` works. `root/defaults/startwm_wayland.sh` is the only consumer and compared the raw value case-sensitively:

```bash
if [ "${SELKIES_DESKTOP}" == "true" ]; then
```

So `True`/`TRUE` fall through to plain `labwc` without `selkies-desktop`. This lowercases the value first, matching the idiom already used throughout `init-selkies-config/run` (`${HARDEN_DESKTOP,,}`, `${DISABLE_SUDO,,}`, `${RESTART_APP,,}`, etc.):

```bash
if [[ "${SELKIES_DESKTOP,,}" == "true" ]]; then
```

## Benefits of this PR and context:
Several other env examples in the README use the `True` spelling, so users reasonably set `SELKIES_DESKTOP=True` and silently get no desktop. This makes the toggle case-insensitive like every other boolean env in the image. closes #164

## How Has This Been Tested?
`bash -n root/defaults/startwm_wayland.sh` passes. Behavioural check of the changed condition: `True`, `true`, `TRUE`, `tRuE` → desktop path (`selkies-desktop`); `false`, empty/unset → plain `labwc` (unchanged). One-line change; file mode (100755) and LF line endings preserved. No Dockerfile ENV default exists for this variable, so no `Dockerfile`/`Dockerfile.aarch64` change is needed and the README stays valid. Reviewer runtime check: launch in Wayland mode (`PIXELFLUX_WAYLAND=true`) with `-e SELKIES_DESKTOP=True` and confirm the labwc panel + selkies-desktop start.

## Source / References:
closes #164
