### PR TITLE
Clean stale runtime state on init so containers recover from unclean shutdowns

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ All application settings are passed via environment variables:
 | NO_DECOR | If set the application will run without window borders for use as a PWA. (Decor can be enabled and disabled with Ctrl+Shift+d) |
 | NO_FULL | Do not autmatically fullscreen applications. |
 | NO_GAMEPAD | Disable userspace gamepad interposer injection. |
-| DISABLE_ZINK | Set to `false` to disable Zink (Mesa OpenGL-on-Vulkan) acceleration for NVIDIA GPUs in X11 mode. Enabled by default when an NVIDIA GPU is detected. |
-| DISABLE_DRI3 | Set to `false` to disable DRI3 GPU passthrough in X11 mode. Enabled by default when a GPU is detected. |
+| DISABLE_ZINK | Set to `true` to disable Zink (Mesa OpenGL-on-Vulkan) acceleration for NVIDIA GPUs in X11 mode. Enabled by default when an NVIDIA GPU is detected. |
+| DISABLE_DRI3 | Set to `true` to disable DRI3 GPU passthrough in X11 mode. Enabled by default when a GPU is detected. |
 | MAX_RES | Pass a larger maximum resolution for the container default is 16k `15360x8640` (X11 only) |
 | WATERMARK_PNG | Full path inside the container to a watermark png IE `/usr/share/selkies/www/icon.png` |
 | WATERMARK_LOCATION | Where to paint the image over the stream integer options below |

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -54,8 +54,8 @@ full_custom_readme: |
   | NO_DECOR | If set the application will run without window borders for use as a PWA. (Decor can be enabled and disabled with Ctrl+Shift+d) |
   | NO_FULL | Do not autmatically fullscreen applications. |
   | NO_GAMEPAD | Disable userspace gamepad interposer injection. |
-  | DISABLE_ZINK | Set to `false` to disable Zink (Mesa OpenGL-on-Vulkan) acceleration for NVIDIA GPUs in X11 mode. Enabled by default when an NVIDIA GPU is detected. |
-  | DISABLE_DRI3 | Set to `false` to disable DRI3 GPU passthrough in X11 mode. Enabled by default when a GPU is detected. |
+  | DISABLE_ZINK | Set to `true` to disable Zink (Mesa OpenGL-on-Vulkan) acceleration for NVIDIA GPUs in X11 mode. Enabled by default when an NVIDIA GPU is detected. |
+  | DISABLE_DRI3 | Set to `true` to disable DRI3 GPU passthrough in X11 mode. Enabled by default when a GPU is detected. |
   | MAX_RES | Pass a larger maximum resolution for the container default is 16k `15360x8640` (X11 only) |
   | WATERMARK_PNG | Full path inside the container to a watermark png IE `/usr/share/selkies/www/icon.png` |
   | WATERMARK_LOCATION | Where to paint the image over the stream integer options below |

--- a/root/etc/s6-overlay/s6-rc.d/init-selkies-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-selkies-config/run
@@ -35,6 +35,9 @@ if [ ! -d "$HOME/.XDG" ]; then
   mkdir -p "$HOME/.XDG"
   chown abc:abc "$HOME/.XDG"
 fi
+# clean out stale runtime state left behind by unclean shutdowns
+find "$HOME/.XDG" -mindepth 1 -delete
+rm -f /defaults/pid /defaults/native
 printf "$HOME/.XDG" > /run/s6/container_environment/XDG_RUNTIME_DIR
 
 # locale Support

--- a/root/etc/s6-overlay/s6-rc.d/init-selkies-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-selkies-config/run
@@ -31,14 +31,13 @@ if [[ ! -f "$CONF_DIR/menu.xml" ]]; then
 fi
 
 # XDG Home
-if [ ! -d "$HOME/.XDG" ]; then
-  mkdir -p "$HOME/.XDG"
-  chown abc:abc "$HOME/.XDG"
-fi
-# clean out stale runtime state left behind by unclean shutdowns
-find "$HOME/.XDG" -mindepth 1 -delete
-rm -f /defaults/pid /defaults/native
+rm -Rf "$HOME/.XDG"
+mkdir -p "$HOME/.XDG"
+chown abc:abc "$HOME/.XDG"
 printf "$HOME/.XDG" > /run/s6/container_environment/XDG_RUNTIME_DIR
+
+# Clean out pulseaudio locks
+rm -f /defaults/pid /defaults/native
 
 # locale Support
 if [ ! -z ${LC_ALL+x} ]; then

--- a/root/etc/s6-overlay/s6-rc.d/svc-selkies/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-selkies/run
@@ -7,15 +7,16 @@ if [ ! -f '/dev/shm/audio.lock' ]; then
   until [ -f /defaults/pid ]; do
     sleep .5
   done
-  s6-setuidgid abc with-contenv pactl \
+  if s6-setuidgid abc with-contenv pactl \
     load-module module-null-sink \
     sink_name="output" \
-    sink_properties=device.description="output"
-  s6-setuidgid abc with-contenv pactl \
-    load-module module-null-sink \
-    sink_name="input" \
-    sink_properties=device.description="input"
-  touch /dev/shm/audio.lock
+    sink_properties=device.description="output" && \
+    s6-setuidgid abc with-contenv pactl \
+      load-module module-null-sink \
+      sink_name="input" \
+      sink_properties=device.description="input"; then
+    touch /dev/shm/audio.lock
+  fi
 fi
 
 # Setup dev mode if defined

--- a/root/etc/s6-overlay/s6-rc.d/svc-xorg/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-xorg/run
@@ -16,7 +16,7 @@ fi
 if [ ! -z ${DRINODE+x} ]; then
   VFBCOMMAND="-vfbdevice ${DRINODE}"
 fi
-if [ "${DISABLE_DRI3}" != "false" ]; then
+if [ "${DISABLE_DRI3,,}" != "false" ]; then
   VFBCOMMAND=""
 fi
 


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-baseimage-selkies/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:

Two supposed-to-be-ephemeral runtime locations survive an unclean container stop (host power loss, hard reboot) because they live on paths that are never wiped:

1. `XDG_RUNTIME_DIR` is pointed at `$HOME/.XDG`, which sits on the persistent `/config` volume. On a normal shutdown the session cleans up after itself, but after an unclean stop stale sockets and session state (wayland/dbus/pipewire leftovers) are still there on the next boot and confuse the fresh session.
2. `PULSE_RUNTIME_PATH` is `/defaults` (set in the Dockerfile), so PulseAudio's `pid` and `native` socket files persist too. `svc-selkies` gates its sink setup on `until [ -f /defaults/pid ]`, so after an unclean stop that gate passes immediately against the *dead* previous instance's pid file. The `pactl load-module` calls then fail against a stale socket, but the script still ran `touch /dev/shm/audio.lock`, which permanently skips sink setup for the rest of that boot, leaving the session without its sinks.

This PR makes the runtime state actually ephemeral and the readiness gate meaningful again:

* `init-selkies-config`: after the existing `$HOME/.XDG` handling, wipe the directory contents on every boot (`find "$HOME/.XDG" -mindepth 1 -delete`) and remove stale `/defaults/pid` and `/defaults/native` so the pulse pid file only exists once the *current* PulseAudio instance has written it.
* `svc-selkies`: only `touch /dev/shm/audio.lock` when both `pactl load-module` calls actually succeeded, so a failed sink setup can retry on service restart instead of being skipped for the whole boot.

Both changes are under `root/`, which is shared by `Dockerfile` and `Dockerfile.aarch64`, so both arches are covered with no Dockerfile changes.

Out of scope: after a power loss PulseAudio's own database files under `/config/.config/pulse` (`*.tdb`) can also end up corrupt; pulse generally recovers from those itself and handling them would mean deleting user-owned config, so this PR deliberately leaves them alone.

## Benefits of this PR and context:

Fixes #166. Users reported that after an unexpected host restart, over half of their selkies containers came up broken (endless wss reconnects in the WebUI, failing http resources) until they manually deleted the non-app data in `/config`. With this change a fresh boot no longer inherits stale runtime state, so containers come up clean after an unclean stop without manual intervention.

## How Has This Been Tested?

* `bash -n` passes on both modified scripts.
* Reproduced the failure mode logically from the scripts: pre-seeding a stale `/defaults/pid` lets the `until` gate pass instantly while `pactl` cannot connect, and previously `audio.lock` was still created; with this change the lock is only created after both sinks load, and a service restart retries the setup.
* The `$HOME/.XDG` wipe runs after the create/chown block in the same init script, so ownership and the `XDG_RUNTIME_DIR` export are unchanged; on a clean first boot the directory is simply empty and the `find`/`rm -f` are no-ops.

## Source / References:

* https://github.com/linuxserver/docker-baseimage-selkies/issues/166