### PR TITLE
fix(env): make DISABLE_DRI3 case-insensitive (the one bool the ,, pass missed)

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/svc-xorg/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-xorg/run
@@ -16,7 +16,7 @@ fi
 if [ ! -z ${DRINODE+x} ]; then
   VFBCOMMAND="-vfbdevice ${DRINODE}"
 fi
-if [ "${DISABLE_DRI3}" != "false" ]; then
+if [ "${DISABLE_DRI3,,}" != "false" ]; then
   VFBCOMMAND=""
 fi
 


### PR DESCRIPTION
The case-insensitive bool pass (from #169) converted the boolean env flags to `${VAR,,}`, but `DISABLE_DRI3` in `root/etc/s6-overlay/s6-rc.d/svc-xorg/run` was missed: that sweep matched `== "true"`/`"false"`, and this comparison is a negated `!= "false"`.

Effect: with the default `DISABLE_DRI3=false` DRI3 is enabled, but a user setting `DISABLE_DRI3=False` or `FALSE` makes `"${DISABLE_DRI3}" != "false"` evaluate true, which clears `-vfbdevice` and silently disables DRI3 GPU passthrough (the opposite of what the user asked for).

One-line fix to `${DISABLE_DRI3,,}`, matching the convention now used for the other flags. Service script only, so no `Dockerfile.aarch64` mirror needed.
