### PR TITLE
Fall back to plain files when mknod is unavailable

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-selkies-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-selkies-config/run
@@ -292,6 +292,19 @@ if [[ -z ${NO_GAMEPAD+x} ]] && mknod /dev/input/js0 c 13 0; then
   mknod /dev/input/event1002 c 13 1066
   mknod /dev/input/event1003 c 13 1067
   chmod 777 /dev/input/js* /dev/input/event*
+elif [[ -z ${NO_GAMEPAD+x} ]] && touch /dev/input/js0; then
+  # Rootless runtimes have no CAP_MKNOD, and the kernel refuses device nodes
+  # inside a userns regardless. The interposer matches on the path name and
+  # never opens the real node, so empty files are enough.
+  printf "/usr/lib/selkies_joystick_interposer.so:/opt/lib/libudev.so.1.0.0-fake" > /run/s6/container_environment/LD_PRELOAD
+  touch /dev/input/js1
+  touch /dev/input/js2
+  touch /dev/input/js3
+  touch /dev/input/event1000
+  touch /dev/input/event1001
+  touch /dev/input/event1002
+  touch /dev/input/event1003
+  chmod 777 /dev/input/js* /dev/input/event*
 else
   printf "false" > /run/s6/container_environment/SELKIES_UI_SIDEBAR_SHOW_GAMEPADS
   printf "false" > /run/s6/container_environment/SELKIES_GAMEPAD_ENABLED


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-baseimage-selkies/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:

Adds an `elif` branch to the gamepad block in `init-selkies-config/run` that falls back to plain files when `mknod` is not available, gated on `touch /dev/input/js0` the same way the existing block is gated on `mknod /dev/input/js0`.

## Benefits of this PR and context:

Under rootless podman there is no CAP_MKNOD, and the kernel refuses device nodes inside a userns anyway, so the `mknod` fails and the whole block drops to the else branch. That sets `SELKIES_GAMEPAD_ENABLED=false` and never writes `LD_PRELOAD` into container_environment, so gamepads are dead in every app and nothing logs why.

Empty files are enough here because the joystick interposer hooks `open()` on the path name and the fake libudev handles enumeration, so nothing ever opens the real node.

## How Has This Been Tested?

Rootless podman on Fedora 43, running the webstation image. Before the change `/dev/input` is empty and `/run/s6/container_environment/LD_PRELOAD` does not exist. After it, the js/event files are created, `LD_PRELOAD` is set, and the gamepad env vars stay at their defaults. Verified controller input reaching PCSX2 through the browser, with connections on `/tmp/selkies_js*.sock`.

Also checked the rootful path is untouched: with `mknod` available the first branch still wins and the `elif` never runs.

## Source / References:

n/a
