### PR TITLE
fix(nginx): treat an empty PASSWORD as no login

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-nginx/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-nginx/run
@@ -40,7 +40,7 @@ fi
 if [ ! -z ${DISABLE_IPV6+x} ]; then
   sed -i '/listen \[::\]/d' ${NGINX_CONFIG}
 fi
-if [ ! -z ${PASSWORD+x} ]; then
+if [ -n "${PASSWORD}" ]; then
   printf "${CUSER}:$(openssl passwd -apr1 ${PASSWORD})\n" > /etc/nginx/.htpasswd
   sed -i 's/#//g' ${NGINX_CONFIG}
 fi

--- a/root/etc/s6-overlay/s6-rc.d/init-nginx/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-nginx/run
@@ -41,7 +41,7 @@ if [ ! -z ${DISABLE_IPV6+x} ]; then
   sed -i '/listen \[::\]/d' ${NGINX_CONFIG}
 fi
 if [ -n "${PASSWORD}" ]; then
-  printf "${CUSER}:$(openssl passwd -apr1 ${PASSWORD})\n" > /etc/nginx/.htpasswd
+  printf '%s:%s\n' "${CUSER}" "$(openssl passwd -apr1 "${PASSWORD}")" > /etc/nginx/.htpasswd
   sed -i 's/#//g' ${NGINX_CONFIG}
 fi
 if [ ! -z ${DEV_MODE+x} ] && [[ "${DEV_MODE}" != "pixelflux" ]]; then


### PR DESCRIPTION
### Description
`init-nginx/run` gates the htpasswd + auth_basic setup on `[ ! -z ${PASSWORD+x} ]`, which is true whenever PASSWORD is merely set, including set-to-empty. An empty `-e PASSWORD=` therefore writes an `.htpasswd` with an empty hash and enables `auth_basic`, leaving the user at a login prompt no password can satisfy.

This bites the Unraid ecosystem in particular: Unraid passes a blank template field as `-e PASSWORD=` (set but empty), so any selkies-based template that exposes an optional PASSWORD field locks users out of a container that was meant to have no login.

### Change
One line: gate on a non-empty value (`[ -n "${PASSWORD}" ]`) instead of merely-set (`${PASSWORD+x}`). Empty or unset now both mean "no login"; a real password still enables basic auth exactly as before.

### Benefits
"Leave it blank for no login" works for all downstreams, and existing installs that pass an empty PASSWORD stop prompting after an update.

Fixes #177
