### PR TITLE
feat(startwm): surface session logs when SELKIES_DEBUG is enabled (openbox + labwc)

### DIFF
--- a/root/defaults/startwm.sh
+++ b/root/defaults/startwm.sh
@@ -7,5 +7,8 @@ if which nvidia-smi > /dev/null 2>&1 && ls -A /dev/dri 2>/dev/null && [ "${DISAB
   export GALLIUM_DRIVER=zink
 fi
 
-# Start DE
-exec dbus-launch --exit-with-session /usr/bin/openbox-session > /dev/null 2>&1
+# Start DE. Output is discarded by default; SELKIES_DEBUG surfaces the openbox
+# session and everything it launches (autostart, app launchers, ready banners)
+# in the container log.
+if [ "${SELKIES_DEBUG,,}" = "true" ]; then LOGDEST=/dev/stdout; else LOGDEST=/dev/null; fi
+exec dbus-launch --exit-with-session /usr/bin/openbox-session > "${LOGDEST}" 2>&1

--- a/root/defaults/startwm_wayland.sh
+++ b/root/defaults/startwm_wayland.sh
@@ -8,6 +8,10 @@ export XKB_DEFAULT_LAYOUT=us
 export XKB_DEFAULT_RULES=evdev
 export WAYLAND_DISPLAY=wayland-1
 
+# Session output is discarded by default; SELKIES_DEBUG surfaces the labwc
+# session in the container log, matching startwm.sh.
+if [ "${SELKIES_DEBUG,,}" = "true" ]; then LOGDEST=/dev/stdout; else LOGDEST=/dev/null; fi
+
 if [ "${PELORUS,,}" == "true" ]; then
   export QT_ACCESSIBILITY=1
   export QT_LINUX_ACCESSIBILITY_ALWAYS_ON=1
@@ -38,11 +42,11 @@ if [ "${PELORUS,,}" == "true" ]; then
       labwc -i
       kill $ATSPI_PID
       kill $PELORUS_PID
-    ' > /dev/null 2>&1
+    ' > "${LOGDEST}" 2>&1
   fi
 else
   if [ "${SELKIES_DESKTOP,,}" == "true" ]; then
-    labwc > /dev/null 2>&1 &
+    labwc > "${LOGDEST}" 2>&1 &
     LABWC_PID=$!
     sleep 1
     export WAYLAND_DISPLAY=wayland-0
@@ -50,6 +54,6 @@ else
     selkies-desktop
     kill $LABWC_PID
   else
-    labwc > /dev/null 2>&1
+    labwc > "${LOGDEST}" 2>&1
   fi
 fi


### PR DESCRIPTION
Currently both session scripts send their output to /dev/null, so `SELKIES_DEBUG=true` cannot tell you why an autostart entry or the desktop itself failed to come up.

This makes the existing `SELKIES_DEBUG` flag also cover session startup: when it is enabled, the openbox session (`startwm.sh`) and the labwc/wayland session (`startwm_wayland.sh`) route their output (autostart, app launchers, ready banners) to the container log. Default behaviour is unchanged and quiet.

No new env var, no fd rebinding, no duplicated code, just the existing redirect made conditional in the two session scripts.
