### PR TITLE
fix(env): treat set-but-empty MAX_RES, DRINODE and DISABLE_IPV6 as unset

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-nginx/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-nginx/run
@@ -37,7 +37,7 @@ s6-setuidgid abc mkdir -p ${FILE_MANAGER_PATH}
 if [[ $SELKIES_FILE_TRANSFERS != *"download"* ]] || [[ ${HARDEN_DESKTOP,,} == "true" ]]; then
   sed -i '/files {/,/^  }/d' ${NGINX_CONFIG}
 fi
-if [ ! -z ${DISABLE_IPV6+x} ]; then
+if [ -n "${DISABLE_IPV6}" ]; then
   sed -i '/listen \[::\]/d' ${NGINX_CONFIG}
 fi
 if [ ! -z ${PASSWORD+x} ]; then

--- a/root/etc/s6-overlay/s6-rc.d/svc-xorg/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-xorg/run
@@ -13,7 +13,7 @@ VFBCOMMAND=""
 if ! which nvidia-smi && [ -e "/dev/dri/renderD128" ]; then
   VFBCOMMAND="-vfbdevice /dev/dri/renderD128"
 fi
-if [ ! -z ${DRINODE+x} ]; then
+if [ -n "${DRINODE}" ]; then
   VFBCOMMAND="-vfbdevice ${DRINODE}"
 fi
 if [ "${DISABLE_DRI3,,}" != "false" ]; then
@@ -22,7 +22,7 @@ fi
 
 # Clamp virtual screen max size based on env
 DEFAULT_RES="15360x8640"
-if [ ! -z ${MAX_RES+x} ]; then
+if [ -n "${MAX_RES}" ]; then
   DEFAULT_RES="${MAX_RES}"
 fi
 if [ -n "${SELKIES_MANUAL_HEIGHT}" ] || [ -n "${SELKIES_MANUAL_WIDTH}" ]; then


### PR DESCRIPTION
### Problem

`svc-xorg` and `init-nginx` gate three env vars with `[ ! -z ${VAR+x} ]`, which is true whenever the variable is merely *set*, including set-to-empty. Unraid passes a blank template field as `-e VAR=` (set but empty), and `-e VAR=` is a plausible manual action in general, so a blank field is treated as a configured value:

- `MAX_RES=` makes `DEFAULT_RES=""`, so Xvfb gets `-screen 0 "x24"` (an invalid geometry) and the X server never starts, taking the whole desktop/stream down.
- `DRINODE=` makes `VFBCOMMAND="-vfbdevice "`, so Xvfb gets a valueless `-vfbdevice` and fails to start.
- `DISABLE_IPV6=` strips the IPv6 `listen` lines even though the user configured nothing.

The same `svc-xorg` file already uses the safe idiom for `SELKIES_MANUAL_WIDTH/HEIGHT` (`[ -n "${VAR}" ]`), so this just applies the same pattern to the remaining vars.

### Fix

Gate on a non-empty value instead of mere presence, so empty and unset both fall back to the default. Same approach as the empty-`PASSWORD` fix in #177/#179.
