### PR TITLE
fix(env): honor documented boolean/case contracts for DISABLE_CLOSE_BUTTON and SELKIES_FILE_TRANSFERS

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-nginx/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-nginx/run
@@ -34,7 +34,7 @@ sed -i "s/CWS/$CWS/g" ${NGINX_CONFIG}
 sed -i "s|SUBFOLDER|$SFOLDER|g" ${NGINX_CONFIG}
 sed -i "s|REPLACE_DOWNLOADS_PATH|$FILE_MANAGER_PATH|g" ${NGINX_CONFIG}
 s6-setuidgid abc mkdir -p ${FILE_MANAGER_PATH}
-if [[ $SELKIES_FILE_TRANSFERS != *"download"* ]] || [[ ${HARDEN_DESKTOP,,} == "true" ]]; then
+if [[ ${SELKIES_FILE_TRANSFERS,,} != *"download"* ]] || [[ ${HARDEN_DESKTOP,,} == "true" ]]; then
   sed -i '/files {/,/^  }/d' ${NGINX_CONFIG}
 fi
 if [ ! -z ${DISABLE_IPV6+x} ]; then

--- a/root/etc/s6-overlay/s6-rc.d/init-selkies-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-selkies-config/run
@@ -158,7 +158,7 @@ if [[ "${PIXELFLUX_WAYLAND,,}" == "true" ]];then
     cp "$DEF_RC" "$USER_RC_XML"
     chown abc:abc "$USER_RC_XML"
     
-    if [[ -n "${DISABLE_CLOSE_BUTTON}" ]]; then
+    if [[ "${DISABLE_CLOSE_BUTTON,,}" == "true" ]]; then
       echo "[ls.io-init] Disabling close button"
       sed -i 's/close//' "$USER_RC_XML"
     fi
@@ -204,7 +204,7 @@ else
     cp "$SYS_RC_XML" "$SYS_RC_BAK"
   fi
   cp "$SYS_RC_BAK" "$SYS_RC_XML"
-  if [[ -n "${DISABLE_CLOSE_BUTTON}" ]]; then
+  if [[ "${DISABLE_CLOSE_BUTTON,,}" == "true" ]]; then
     echo "[ls.io-init] Disabling close button"
     sed -i '/<titleLayout>/s/C//' "$SYS_RC_XML"
   fi


### PR DESCRIPTION
Two env vars do not honor their documented contract.

### DISABLE_CLOSE_BUTTON

Documented as "If true, removes the close button from window title bars", and set to `"true"` by `HARDEN_OPENBOX`. But both checks use `[[ -n "${DISABLE_CLOSE_BUTTON}" ]]` (presence), so `DISABLE_CLOSE_BUTTON=false` still removes the close button. Its siblings (`DISABLE_MOUSE_BUTTONS`, `HARDEN_KEYBINDS`) already use `${VAR,,} == "true"`. Switched both occurrences (the openbox `USER_RC_XML` path and the labwc `SYS_RC_XML` path) to match.

### SELKIES_FILE_TRANSFERS

The nginx download-endpoint gate is case-sensitive (`!= *"download"*`), so `SELKIES_FILE_TRANSFERS=Download` silently strips the files location while the selkies core still treats downloads as enabled. Lowercased the comparison so it matches regardless of case.
