### PR TITLE
fix(svc-de): depend on legacy-cont-init so runtime env writes complete before the desktop starts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -464,7 +464,7 @@ RUN \
     /tmp/wl.deb && \
   echo "**** install selkies ****" && \
   SELKIES_RELEASE=$(curl -sX GET "https://api.github.com/repos/selkies-project/selkies/releases/latest" \
-    | awk '/tag_name/{print $4;exit}' FS='[""]') && \
+    | jq -r '.tag_name') && \
   curl -o \
     /tmp/selkies.tar.gz -L \
     "https://github.com/selkies-project/selkies/archive/348bc4f61da66198573e7e57db9a266aca1991d5.tar.gz" && \
@@ -482,7 +482,7 @@ RUN \
   echo "**** install pelorus ****" && \
   mkdir -p /tmp/pelorus && \
   PELORUS_RELEASE=$(curl -sX GET "https://api.github.com/repos/linuxserver/pelorus/releases/latest" \
-    | awk '/tag_name/{print $4;exit}' FS='[""]') && \
+    | jq -r '.tag_name') && \
   curl -o \
     /tmp/pelorus.tar.gz -L \
     "https://github.com/linuxserver/pelorus/archive/${PELORUS_RELEASE}.tar.gz" && \
@@ -534,7 +534,7 @@ RUN \
   echo "**** proot-apps ****" && \
   mkdir /proot-apps/ && \
   PAPPS_RELEASE=$(curl -sX GET "https://api.github.com/repos/linuxserver/proot-apps/releases/latest" \
-    | awk '/tag_name/{print $4;exit}' FS='[""]') && \
+    | jq -r '.tag_name') && \
   curl -L https://github.com/linuxserver/proot-apps/releases/download/${PAPPS_RELEASE}/proot-apps-x86_64.tar.gz \
     | tar -xzf - -C /proot-apps/ && \
   echo "${PAPPS_RELEASE}" > /proot-apps/pversion && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -460,7 +460,7 @@ RUN \
     /tmp/wl.deb && \
   echo "**** install selkies ****" && \
   SELKIES_RELEASE=$(curl -sX GET "https://api.github.com/repos/selkies-project/selkies/releases/latest" \
-    | awk '/tag_name/{print $4;exit}' FS='[""]') && \
+    | jq -r '.tag_name') && \
   curl -o \
     /tmp/selkies.tar.gz -L \
     "https://github.com/selkies-project/selkies/archive/348bc4f61da66198573e7e57db9a266aca1991d5.tar.gz" && \
@@ -478,7 +478,7 @@ RUN \
   echo "**** install pelorus ****" && \
   mkdir -p /tmp/pelorus && \
   PELORUS_RELEASE=$(curl -sX GET "https://api.github.com/repos/linuxserver/pelorus/releases/latest" \
-    | awk '/tag_name/{print $4;exit}' FS='[""]') && \
+    | jq -r '.tag_name') && \
   curl -o \
     /tmp/pelorus.tar.gz -L \
     "https://github.com/linuxserver/pelorus/archive/${PELORUS_RELEASE}.tar.gz" && \
@@ -530,7 +530,7 @@ RUN \
   echo "**** proot-apps ****" && \
   mkdir /proot-apps/ && \
   PAPPS_RELEASE=$(curl -sX GET "https://api.github.com/repos/linuxserver/proot-apps/releases/latest" \
-    | awk '/tag_name/{print $4;exit}' FS='[""]') && \
+    | jq -r '.tag_name') && \
   curl -L https://github.com/linuxserver/proot-apps/releases/download/${PAPPS_RELEASE}/proot-apps-aarch64.tar.gz \
     | tar -xzf - -C /proot-apps/ && \
   echo "${PAPPS_RELEASE}" > /proot-apps/pversion && \

--- a/README.md
+++ b/README.md
@@ -228,6 +228,8 @@ All base images are built for x86_64 and aarch64 platforms.
 | Kali | kali |
 | Ubuntu | ubunturesolute |
 
+**A `dev` tag is also available based on the latest Ubuntu and the head Selkies codebase for integration testing.**
+
 ### Control Plane API for Token Management
 
 When secure mode is enabled (`SELKIES_MASTER_TOKEN` is set), the server runs a control plane API on the `control_port` (default: 8083). This API is used to dynamically set and update the access tokens that clients can use to connect. This control plane port is meant for integrators that want to wrap the baseimage in their own platforms and handle authentication, this port should never be exposed publically.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -232,6 +232,8 @@ full_custom_readme: |
   | Kali | kali |
   | Ubuntu | ubunturesolute |
 
+  **A `dev` tag is also available based on the latest Ubuntu and the head Selkies codebase for integration testing.**
+
   ### Control Plane API for Token Management
 
   When secure mode is enabled (`SELKIES_MASTER_TOKEN` is set), the server runs a control plane API on the `control_port` (default: 8083). This API is used to dynamically set and update the access tokens that clients can use to connect. This control plane port is meant for integrators that want to wrap the baseimage in their own platforms and handle authentication, this port should never be exposed publically.


### PR DESCRIPTION
Fixes #178.

`svc-de/run` starts with `#!/usr/bin/with-contenv bash`, so it snapshots the container environment when it starts. Variables a downstream `cont-init.d` script writes at runtime into `/run/s6/container_environment/` are produced by the legacy cont-init compatibility oneshot, which is not a declared dependency of `svc-de` (`s6-rc-db all-dependencies svc-de` does not list it). On slow storage the desktop can win the race and start openbox, and whatever it launches, before those variables exist.

This adds a dependency edge from `svc-de` to `legacy-cont-init`, so the desktop only starts after the legacy `cont-init.d` scripts and their env writes have completed. It is an additive ordering edge with no behaviour change on fast storage.
